### PR TITLE
Support running multiple redis instances on same machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,7 @@
 
 ## Usage
 ### Supports
-- Ubuntu 
-
-Currently this does not support sentinal but it will in due time.
+- Ubuntu
 
 ### Dependencies
 | Name | Description |
@@ -31,13 +29,13 @@ You have the ability to tune everything and anything redis. You simply have to p
 
 ```ruby
 redis_instance "redis" do
-  bind "172.16.10.10
+  bind "172.16.10.10"
 end
 ```
 
 You have the ability to enable sentinel with the below block.
-```ruby 
-redis_instance "redis" do 
+```ruby
+redis_instance "redis" do
   sentinel true
 end
 ```

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -6,7 +6,7 @@ module RedisCookbook
 
     # Get config file location based on redis instance name
     def config_path
-      ::File.join(new_resource.config_dir,"#{new_resource.instance_name}.conf")
+      ::File.join(new_resource.config_dir, "#{new_resource.instance_name}.conf")
     end
 
     # Method for start command if sentinel is being used.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -4,35 +4,15 @@ module RedisCookbook
   module Helpers
     include Chef::DSL::IncludeRecipe
 
-    # Define configuration directory for the different platforms
-    def config_dir
-      case node.platform_family
-      when 'debian'
-        '/etc/redis'
-      else
-        '/etc/'
-      end
-    end
-
-    # Since other platforms like to name the files differently.
-    def sentinel_config
-      case node.platform_family
-      when 'debian'
-        "#{config_dir}/sentinel.conf"
-      else
-        "#{config_dir}/redis-sentinel.conf"
-      end
+    # Get config file location based on redis instance name
+    def config_path
+      ::File.join(new_resource.config_dir,"#{new_resource.instance_name}.conf")
     end
 
     # Method for start command if sentinel is being used.
     def start_command
-      start = '/usr/bin/redis-server'
-      case new_resource.sentinel
-      when true
-        "#{start} #{sentinel_config} --sentinel"
-      when false
-        "#{start} #{config_dir}/redis.conf"
-      end
+      command = "/usr/bin/redis-server #{config_path}"
+      new_resource.sentinel ? "#{command} --sentinel" : command
     end
   end
 end

--- a/libraries/redis_instance.rb
+++ b/libraries/redis_instance.rb
@@ -176,9 +176,14 @@ module RedisCookbook
       def action_disable
         super
         notifying_block do
+          file config_path do
+            action :delete
+          end
+
           directory new_resource.config_dir do
             action :delete
             not_if { new_resource.config_dir == '/etc' }
+            only_if { Dir["#{new_resource.config_dir}/*"].empty? }
           end
         end
       end

--- a/libraries/redis_instance.rb
+++ b/libraries/redis_instance.rb
@@ -15,9 +15,9 @@ module RedisCookbook
       provides(:redis_instance)
       include PoiseService::ServiceMixin
 
-      # @!attribute config_name
+      # @!attribute instance_name
       # @return [String]
-      attribute(:config_name, kind_of: String, name_attribute: true)
+      attribute(:instance_name, kind_of: String, name_attribute: true)
 
       # @!attribute pkg
       # @return [String]
@@ -29,14 +29,22 @@ module RedisCookbook
 
       # @!attribute user
       # @return [String]
-      attribute(:user, kind_of: String, default: 'root')
+      attribute(:user, kind_of: String, default: 'redis')
 
       # @!attribute group
       # @return [String]
-      attribute(:group, kind_of: String, default: 'root')
+      attribute(:group, kind_of: String, default: 'redis')
+
+      # @!attribute config_dir
+      # @return [String]
+      attribute(:config_dir, kind_of: String, default: '/etc/redis')
+
+      # @!attribute log_dir
+      # @return [String]
+      attribute(:log_dir, kind_of: String, default: '/var/log/redis/')
+
 
       # @see: https://raw.githubusercontent.com/antirez/redis/2.8/redis.conf
-      attribute(:pid_file, kind_of: String, default: '/var/run/redis/redis-server.pid')
       attribute(:port, kind_of: Integer, default: '6379')
       attribute(:bind, kind_of: String, default: '0.0.0.0')
       attribute(:unixsocket, kind_of: [String, NilClass], default: nil)
@@ -46,13 +54,13 @@ module RedisCookbook
       attribute(:syslog_enabled, kind_of: [String, NilClass], default: nil)
       attribute(:syslog_ident, kind_of: [String, NilClass], default: nil)
       attribute(:syslog_facility, kind_of: [String, NilClass], default: nil)
-      attribute(:logfile, kind_of: String, default: '/var/log/redis/redis-server.log')
+      attribute(:logfile, kind_of: String, default: lazy { ::File.join(log_dir,"#{instance_name}.log") })
       attribute(:databases, kind_of: Integer, default: '16')
       attribute(:save, kind_of: [String, Array], default: ['900 1', '300 10', '60 10000'])
       attribute(:stop_writes_on_bgsave_error, equal_to: %w{yes no}, default: 'yes')
       attribute(:rdbcompression, equal_to: %w{yes no}, default: 'yes')
       attribute(:rdbchecksum, equal_to: %w{yes no}, default: 'yes')
-      attribute(:dir, kind_of: String, default: '/var/lib/redis')
+      attribute(:dir, kind_of: String, default: lazy { "/var/lib/redis/#{instance_name}" })
       attribute(:slaveof, kind_of: [String, Array, NilClass], default: nil)
       attribute(:masterauth, kind_of: [String, NilClass], default: nil)
       attribute(:slave_serve_stale_data, equal_to: %w{yes no}, default: 'yes')
@@ -120,34 +128,44 @@ module RedisCookbook
             package_name new_resource.pkg
             version new_resource.version unless new_resource.version.nil?
             action :upgrade
+            notifies :restart, new_resource
           end
 
-          directory config_dir do
+          # Installing package starts redis service automatically
+          # Disable this so that redis can be managed through poise-service
+          service new_resource.pkg do
+            action [:disable,:stop]
+          end
+
+          directory new_resource.dir do
+            recursive true
+          end
+
+          directory new_resource.config_dir do
             recursive true
             action :create
           end
 
           # Place configuration file on the filesystem
-          template "#{new_resource.config_name} :create #{config_dir}/redis.conf" do
-            path "#{config_dir}/redis.conf"
+          template 'redis-server-config' do
+            path config_path
             source 'redis.conf.erb'
-            variables(
-              config: new_resource
-            )
+            variables(config: new_resource)
             cookbook 'redis'
             owner new_resource.user
             group new_resource.group
+            not_if { new_resource.sentinel }
+            notifies :restart, new_resource
           end
-
-          unless new_resource.sentinel == false
-            template "#{sentinel_config} :create #{sentinel_config}" do
-              path sentinel_config
-              source 'sentinel.conf.erb'
-              variables(config: new_resource)
-              cookbook 'redis'
-              owner new_resource.user
-              group new_resource.group
-            end
+          template 'redis-sentinel-config' do
+            path config_path
+            source 'sentinel.conf.erb'
+            variables(config: new_resource)
+            cookbook 'redis'
+            owner new_resource.user
+            group new_resource.group
+            only_if { new_resource.sentinel }
+            notifies :restart, new_resource
           end
         end
         super
@@ -158,18 +176,17 @@ module RedisCookbook
       def action_disable
         super
         notifying_block do
-          directory config_dir do
+          directory new_resource.config_dir do
             action :delete
-            not_if { config_dir == '/etc' }
+            not_if { new_resource.config_dir == '/etc' }
           end
         end
       end
 
       def service_options(service)
-        service.service_name('redis')
         service.command(start_command)
-        service.directory('/var/run/redis')
-        service.user('redis')
+        service.directory(new_resource.dir)
+        service.user(new_resource.user)
         service.restart_on_update(true)
       end
     end

--- a/libraries/redis_instance.rb
+++ b/libraries/redis_instance.rb
@@ -43,7 +43,6 @@ module RedisCookbook
       # @return [String]
       attribute(:log_dir, kind_of: String, default: '/var/log/redis/')
 
-
       # @see: https://raw.githubusercontent.com/antirez/redis/2.8/redis.conf
       attribute(:port, kind_of: Integer, default: '6379')
       attribute(:bind, kind_of: String, default: '0.0.0.0')
@@ -54,7 +53,7 @@ module RedisCookbook
       attribute(:syslog_enabled, kind_of: [String, NilClass], default: nil)
       attribute(:syslog_ident, kind_of: [String, NilClass], default: nil)
       attribute(:syslog_facility, kind_of: [String, NilClass], default: nil)
-      attribute(:logfile, kind_of: String, default: lazy { ::File.join(log_dir,"#{instance_name}.log") })
+      attribute(:logfile, kind_of: String, default: lazy { ::File.join(log_dir, "#{instance_name}.log") })
       attribute(:databases, kind_of: Integer, default: '16')
       attribute(:save, kind_of: [String, Array], default: ['900 1', '300 10', '60 10000'])
       attribute(:stop_writes_on_bgsave_error, equal_to: %w{yes no}, default: 'yes')
@@ -134,7 +133,7 @@ module RedisCookbook
           # Installing package starts redis service automatically
           # Disable this so that redis can be managed through poise-service
           service new_resource.pkg do
-            action [:disable,:stop]
+            action [:disable, :stop]
           end
 
           directory new_resource.dir do
@@ -161,7 +160,6 @@ module RedisCookbook
             group new_resource.group
             notifies :restart, new_resource
           end
-
         end
         super
       end

--- a/libraries/redis_instance.rb
+++ b/libraries/redis_instance.rb
@@ -147,26 +147,16 @@ module RedisCookbook
           end
 
           # Place configuration file on the filesystem
-          template 'redis-server-config' do
-            path config_path
-            source 'redis.conf.erb'
+          config_source = new_resource.sentinel ? 'sentinel.conf.erb' : 'redis.conf.erb'
+          template config_path do
+            source config_source
             variables(config: new_resource)
             cookbook 'redis'
             owner new_resource.user
             group new_resource.group
-            not_if { new_resource.sentinel }
             notifies :restart, new_resource
           end
-          template 'redis-sentinel-config' do
-            path config_path
-            source 'sentinel.conf.erb'
-            variables(config: new_resource)
-            cookbook 'redis'
-            owner new_resource.user
-            group new_resource.group
-            only_if { new_resource.sentinel }
-            notifies :restart, new_resource
-          end
+
         end
         super
       end

--- a/libraries/redis_instance.rb
+++ b/libraries/redis_instance.rb
@@ -139,11 +139,16 @@ module RedisCookbook
 
           directory new_resource.dir do
             recursive true
+            user new_resource.user
+            group new_resource.group
+            mode '0755'
           end
 
           directory new_resource.config_dir do
             recursive true
-            action :create
+            user new_resource.user
+            group new_resource.group
+            mode '0755'
           end
 
           # Place configuration file on the filesystem

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Anthony Caiafa'
 maintainer_email '2600.ac@gmail.com'
 description 'Application cookbook which installs and configures Redis.'
 long_description 'Application cookbook which installs and configures Redis.'
-version '1.0.0'
+version '1.0.1'
 
 supports 'redhat', '>= 5.8'
 supports 'centos', '>= 5.8'

--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -14,13 +14,8 @@
 
 # By default Redis does not run as a daemon. Use 'yes' if you need it.
 # Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
-daemonize yes
-
-# When running daemonized, Redis writes a pid file in /var/run/redis.pid by
-# default. You can specify a custom pid file location here.
-<% if @config.pid_file %>
-pidfile <%= @config.pid_file %>
-<% end %>
+# Daemonizing is managed by poise-service
+daemonize no
 
 # Accept connections on the specified port, default is 6379.
 # If port 0 is specified Redis will not listen on a TCP socket.

--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -35,7 +35,7 @@ bind <%= @config.bind %>
 #
 # unixsocket /var/run/redis/redis.sock
 # unixsocketperm 755
-<% if @config.unixsocket %> 
+<% if @config.unixsocket %>
 unixsocket <%= @config.unixsocket %>
 <% end %>
 <% if @config.unixsocketperm %>
@@ -130,7 +130,7 @@ databases <%= @config.databases.to_s %>
 # and persistence, you may want to disable this feature so that Redis will
 # continue to work as usually even if there are problems with disk,
 # permissions, and so forth.
-<% if @config.stop_writes_on_bgsave_error %> 
+<% if @config.stop_writes_on_bgsave_error %>
 stop-writes-on-bgsave-error <%= @config.stop_writes_on_bgsave_error %>
 <% end %>
 
@@ -179,8 +179,12 @@ dir <%= @config.dir %>
 #
 # slaveof <masterip> <masterport>
 <% if @config.slaveof %>
-  <% @config.slaveof.each do |s| %>
+  <% if @config.slaveof.kind_of?(Array) %>
+      <% @config.slaveof.each do |s| %>
 <%= "slaveof #{s}" %>
+      <% end %>
+  <% else %>
+<%= "slaveof #{@config.slaveof}" %>
   <% end %>
 <% end %>
 

--- a/templates/default/sentinel.conf.erb
+++ b/templates/default/sentinel.conf.erb
@@ -6,6 +6,22 @@
 port <%= @config.sentinel_port %>
 <% end %>
 
+# dir <working-directory>
+# Every long running process should have a well-defined working directory.
+# For Redis Sentinel to chdir to /tmp at startup is the simplest thing
+# for the process to don't interfere with administrative tasks such as
+# unmounting filesystems.
+<% if @config.dir %>
+dir <%= @config.dir %>
+<% end %>
+
+# Specify the log file name. Also 'stdout' can be used to force
+# Redis to log on the standard output. Note that if you use standard
+# output for logging but daemonize, logs will be sent to /dev/null
+<% if @config.logfile %>
+logfile <%= @config.logfile %>
+<% end %>
+
 # sentinel monitor <%= @config.sentinel_master_name %> <ip> <redis-port> <quorum>
 #
 # Tells Sentinel to monitor this master, and to consider it in O_DOWN


### PR DESCRIPTION
1. Create instance specific log file, working directory, configuration file so that multiple redis instances can be run on same machine
2.  Disable redis init service brought up by installing redis server packge and manage service through poise
3. Minor fixes in configuration template

cc @acaiafa 